### PR TITLE
fix(deps): export type for RouterContext, Middleware, LevelName & Spy

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,9 +3,11 @@
 export {
   Router,
   Application,
-  RouterContext,
   Context,
   Response,
+} from "https://deno.land/x/oak@v6.0.1/mod.ts";
+export type {
+  RouterContext,
   Middleware,
 } from "https://deno.land/x/oak@v6.0.1/mod.ts";
 export { Status, STATUS_TEXT } from "https://deno.land/std@0.62.0/http/http_status.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -16,7 +16,8 @@ export {
   assertThrows,
   assertStrictEquals,
 } from "https://deno.land/std@0.62.0/testing/asserts.ts";
-export { spy, Spy } from "https://deno.land/x/mock@v0.5.1/spy.ts";
+export { spy } from "https://deno.land/x/mock@v0.5.1/spy.ts";
+export type { Spy } from "https://deno.land/x/mock@v0.5.1/spy.ts";
 export {
   green,
   red,
@@ -26,4 +27,4 @@ export {
   white,
 } from "https://deno.land/std@0.62.0/fmt/colors.ts";
 export { v4 } from "https://deno.land/std@0.62.0/uuid/mod.ts";
-export * as log from "https://deno.land/std@0.62.0/log/mod.ts";
+export * as log from "https://deno.land/std@0.65.0/log/mod.ts";


### PR DESCRIPTION
- Fixes TS1205 error by `export`ing `RouterContext`, `Middleware`, `LevelName` & `Spy` as `type`
- Uses [`std` `v0.65.0`]('https://deno.land/std@0.65.0/log')